### PR TITLE
Fixed computed property name in data.md

### DIFF
--- a/en/data.md
+++ b/en/data.md
@@ -97,7 +97,7 @@ export default {
 
   computed: {
     // display the item from store state.
-    items () {
+    item () {
       return this.$store.state.items[this.$route.params.id]
     }
   }


### PR DESCRIPTION
Hello,
I discovered and fixed a minor error in the naming of a computed property in `data.md`. I believe it's supposed to be `item` and not `items`.
Great work putting this guide together!