### PR TITLE
Doc EN: Hello and Webpack case

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -37,7 +37,7 @@ Before using SSR for your app, the first question you should ask it whether you 
 
 If you're only investigating SSR to improve the SEO of a handful of marketing pages (e.g. `/`, `/about`, `/contact`, etc), then you probably want __prerendering__ instead. Rather than using a web server to compile HTML on-the-fly, prerendering simply generates static HTML files for specific routes at build time. The advantage is setting up prerendering is much simpler and allows you to keep your frontend as a fully static site.
 
-If you're using Webpack, you can easily add prerendering with the [prerender-spa-plugin](https://github.com/chrisvfritz/prerender-spa-plugin). It's been extensively tested with Vue apps - and in fact, [the creator](https://github.com/chrisvfritz) is a member of the Vue core team.
+If you're using webpack, you can easily add prerendering with the [prerender-spa-plugin](https://github.com/chrisvfritz/prerender-spa-plugin). It's been extensively tested with Vue apps - and in fact, [the creator](https://github.com/chrisvfritz) is a member of the Vue core team.
 
 ## About This Guide
 

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -24,4 +24,4 @@
     - [basedir](api.md#basedir)
     - [cache](api.md#cache)
     - [directives](api.md#directives)
-  - [Webpack Plugins](api.md#webpack-plugins)
+  - [webpack Plugins](api.md#webpack-plugins)

--- a/en/api.md
+++ b/en/api.md
@@ -211,7 +211,7 @@ See [Introducing the Server Bundle](./bundle-renderer.md) and [Build Configurati
 
   As an example, check out [`v-show`'s server-side implementation](https://github.com/vuejs/vue/blob/dev/src/platforms/web/server/directives/show.js).
 
-## Webpack Plugins
+## webpack Plugins
 
 The webpack plugins are provided as standalone files and should be required directly:
 

--- a/en/basic.md
+++ b/en/basic.md
@@ -30,7 +30,7 @@ const renderer = require('vue-server-renderer').createRenderer()
 renderer.renderToString(app, (err, html) => {
   if (err) throw err
   console.log(html)
-  // => <div data-server-rendered="true">hello world</div>
+  // => <div data-server-rendered="true">Hello World</div>
 })
 ```
 
@@ -134,7 +134,7 @@ const context = {
 }
 
 renderer.renderToString(app, context, (err, html) => {
-  // page title will be "hello"
+  // page title will be "Hello"
   // with meta tags injected
 })
 ```

--- a/en/structure.md
+++ b/en/structure.md
@@ -57,7 +57,7 @@ So the basic idea is we will be using webpack to bundle our app for both client 
 
 We will discuss the details of the setup in later sections - for now, let's just assume we've got the build setup figured out and we can write our Vue app code with webpack enabled.
 
-## Code Structure with Webpack
+## Code Structure with webpack
 
 Now that we are using webpack to process the app for both server and client, the majority of our source code can be written in a universal fashion, with access to all the webpack-powered features. At the same time, there are [a number of things](./universal.md) you should keep in mind when writing universal code.
 


### PR DESCRIPTION
- No consistency between « hello » and « world » terms fix
- No usage of lower capital to « webpack » word fix (even as starting word
   - — see https://webpack.js.org/configuration/ for phrase majuscule example 
   - — see https://webpack.js.org/development/release-process/ for link/title example)