### PR TITLE
Changed '{{{ meta }}}' to a v-html directive

### DIFF
--- a/en/basic.md
+++ b/en/basic.md
@@ -120,8 +120,8 @@ The template also supports simple interpolation. Given the following template:
     <!-- use double mustache for HTML-escaped interpolation -->
     <title>{{ title }}</title>
 
-    <!-- use triple mustache for non-HTML-escaped interpolation -->
-    {{{ meta }}}
+    <!-- use v-html directive for Non HTML-escaped interpolation -->
+  <div v-html="meta"></div>
   </head>
   <body>
     <!--vue-ssr-outlet-->


### PR DESCRIPTION
'{{{ }}}' is deprecated... right?
https://vuejs.org/v2/guide/migration.html#HTML-Interpolation-removed

