### PR TITLE
docs: Improve wording and fix 'readble' typo

### DIFF
--- a/en/api.md
+++ b/en/api.md
@@ -38,7 +38,7 @@ See [Introducing the Server Bundle](./bundle-renderer.md) and [Build Configurati
 
 - #### `renderer.renderToStream(vm[, context]): stream.Readable`
 
-  Render a Vue instance to a [Node.js readble stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
+  Render a Vue instance to a [Node.js readable stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
 
 ## `Class: BundleRenderer`
 
@@ -50,7 +50,7 @@ See [Introducing the Server Bundle](./bundle-renderer.md) and [Build Configurati
 
 - #### `bundleRenderer.renderToStream([context]): stream.Readable`
 
-  Render the bundle to a [Node.js readble stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
+  Render the bundle to a [Node.js readable stream](https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_streams). The context object is optional. See [Streaming](./streaming.md) for more details.
 
 ## Renderer Options
 

--- a/en/css.md
+++ b/en/css.md
@@ -85,7 +85,7 @@ A few things to take note when importing CSS from an NPM dependency:
 
 1. It should not be externalized in the server build.
 
-2. If using CSS extraction + vendor extracting with `CommonsChunkPlugin`, `extract-text-webpack-plugin` will run into problems if the extracted CSS in inside an extracted vendors chunk. To work around this, avoid including CSS files in the vendor chunk. An example client webpack config:
+2. If using CSS extraction + vendor extracting with `CommonsChunkPlugin`, `extract-text-webpack-plugin` will run into problems if the extracted CSS is inside an extracted vendors chunk. To work around this, avoid including CSS files in the vendor chunk. An example client webpack config:
 
   ``` js
   module.exports = {

--- a/en/streaming.md
+++ b/en/streaming.md
@@ -28,6 +28,6 @@ stream.on('error', err => {
 
 In stream rendering mode, data is emitted as soon as possible when the renderer traverses the Virtual DOM tree. This means we can get an earlier "first chunk" and start sending it to the client faster.
 
-However, when the first data chunk is emitted, the child components may not even be instantiated yet, neither will their lifecycle hooks get called. This means if the child components need to attach data to the render context in their lifecycle hooks, these data will not be available when the stream starts. Since a lot of the context information (like head information or inlined critical CSS) needs to be appear before the application markup, we essentially have to wait until the stream to complete before we can start making use of these context data.
+However, when the first data chunk is emitted, the child components may not even be instantiated yet, neither will their lifecycle hooks get called. This means if the child components need to attach data to the render context in their lifecycle hooks, these data will not be available when the stream starts. Since a lot of the context information (like head information or inlined critical CSS) needs to appear before the application markup, we essentially have to wait until the stream to complete before we can start making use of these context data.
 
 It is therefore **NOT** recommended to use streaming mode if you rely on context data populated by component lifecycle hooks.


### PR DESCRIPTION
Hey, I spotted some typos in the docs