### PR TITLE
Add redirects for ja

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -12,3 +12,8 @@
 /ru/api.html    /ru/api/
 /ru/basic.html  /ru/guide/
 /ru/*           /ru/guide/:splat
+
+/ja/            /ja/
+/ja/api.html    /ja/api/
+/ja/basic.html  /ja/guide/
+/ja/*           /ja/guide/:splat


### PR DESCRIPTION
Add redirects for ja pages.

currently, no redirect for ja, so some links to the vue-ssr-docs ja on vuex ja docs are broken.
(e.g. link to vue-ssr on [this page](https://vuex.vuejs.org/ja/guide/modules.html#%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%AE%E5%86%8D%E5%88%A9%E7%94%A8))

however, i could not be tested redirect on locally.
if these change contain problem, please close this pr.