### PR TITLE
Remove trailing ` after HTML code block.

### DIFF
--- a/docs-gitbook/fr/build-config.md
+++ b/docs-gitbook/fr/build-config.md
@@ -143,7 +143,7 @@ Avec cette mise en place, votre rendu HTML côté serveur pour un build avec sci
     <script src="/0.js"></script>
     <script src="/main.js"></script>
   </body>
-</html>`
+</html>
 ```
 
 ### Injection manuelle des fichiers

--- a/docs-gitbook/ko/build-config.md
+++ b/docs-gitbook/ko/build-config.md
@@ -115,8 +115,8 @@ const renderer = createBundleRenderer(serverBundle, {
 이 설정을 사용하면 코드 분할을 사용하는 빌드의 서버렌더링된 HTML이 다음과 같이 표시됩니다.(전체가 자동으로 주입됩니다)
 
 ```html
-
-
+<html>
+  <head>
     <!-- chunks used for this render will be preloaded -->
     <link rel="preload" href="/manifest.js" as="script">
     <link rel="preload" href="/main.js" as="script">
@@ -132,8 +132,8 @@ const renderer = createBundleRenderer(serverBundle, {
     <!-- async chunks injected before main chunk -->
     <script src="/0.js"></script>
     <script src="/main.js"></script>
-
-`
+  </body>
+</html>
 ```
 
 ### 수동 에셋 주입

--- a/docs-gitbook/ru/build-config.md
+++ b/docs-gitbook/ru/build-config.md
@@ -142,7 +142,7 @@ const renderer = createBundleRenderer(serverBundle, {
     <script src="/0.js"></script>
     <script src="/main.js"></script>
   </body>
-</html>`
+</html>
 ```
 
 ### Внедрение ресурсов вручную

--- a/docs/guide/build-config.md
+++ b/docs/guide/build-config.md
@@ -143,7 +143,7 @@ With this setup, your server-rendered HTML for a build with code-splitting will 
     <script src="/0.js"></script>
     <script src="/main.js"></script>
   </body>
-</html>`
+</html>
 ```
 
 ### Manual Asset Injection

--- a/docs/ru/guide/build-config.md
+++ b/docs/ru/guide/build-config.md
@@ -142,7 +142,7 @@ const renderer = createBundleRenderer(serverBundle, {
     <script src="/0.js"></script>
     <script src="/main.js"></script>
   </body>
-</html>`
+</html>
 ```
 
 ### Внедрение ресурсов вручную

--- a/docs/zh/guide/build-config.md
+++ b/docs/zh/guide/build-config.md
@@ -143,7 +143,7 @@ const renderer = createBundleRenderer(serverBundle, {
     <script src="/0.js"></script>
     <script src="/main.js"></script>
   </body>
-</html>`
+</html>
 ```
 
 ### 手动资源注入(Manual Asset Injection)


### PR DESCRIPTION
A small formatting fix for an issue I noticed whilst reading the docs.