### PR TITLE
Fix Japanese Docs : computed key from 'items' to 'item'

### DIFF
--- a/docs-gitbook/ja/data.md
+++ b/docs-gitbook/ja/data.md
@@ -87,7 +87,7 @@ export default {
   },
   computed: {
     // ストアの状態から item を表示します
-    items () {
+    item () {
       return this.$store.state.items[this.$route.params.id]
     }
   }

--- a/docs/ja/guide/data.md
+++ b/docs/ja/guide/data.md
@@ -96,7 +96,7 @@ export default {
 
   computed: {
     // ストアの状態から item を表示します
-    items () {
+    item () {
       return this.$store.state.items[this.$route.params.id]
     }
   }


### PR DESCRIPTION
I found some mistake in Japanese Docs.

Compared  [English docs](https://github.com/vuejs/vue-ssr-docs/blob/master/docs/guide/data.md#logic-collocation-with-components), and [Japanese docs](https://github.com/vuejs/vue-ssr-docs/blob/master/docs/ja/guide/data.md#ロジックとコンポーネントとの結び付き), this is obviously mistake.

This is my first time pull request ever, so if you find some mistake in my process of pull request, please point out it. 
Thanks.