### PR TITLE
docs: adds import app in entry-client

### DIFF
--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -182,6 +182,8 @@ When using `template`, `context.state` will automatically be embedded in the fin
 ``` js
 // entry-client.js
 
+import { createApp } from './app'
+
 const { app, store } = createApp()
 
 if (window.__INITIAL_STATE__) {


### PR DESCRIPTION
Just importing app in `entry-client.js` too.
Nothing fancy to review here :)