### PR TITLE
docs: fixes client-side navigation when lazy-register store module

### DIFF
--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -243,15 +243,15 @@ export default {
   },
 
   // Client-side only
-  mounted () {
-    // We already incremented 'count' on the server
-    // We know by checking if the 'foo' state already exists
-    const alreadyIncremented = !!this.$store.state.foo
+  beforeMount () {
+    // We have to check if there is no data
+    const storeCountEmpty = !!this.$store.state.foo.count
 
     // We register the foo module
     this.registerFoo()
 
-    if (!alreadyIncremented) {
+    // Check if there is no data and fetch it
+    if (storeCountEmpty) {
       this.fooInc()
     }
   },

--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -265,7 +265,7 @@ export default {
   methods: {
     registerFoo () {
       // Preserve the previous state if it was injected from the server
-      this.$store.registerModule('foo', fooStoreModule, { preserveState: true })
+      this.$store.registerModule('foo', fooStoreModule, { preserveState: !!this.$store.state.foo })
     },
 
     fooInc () {


### PR DESCRIPTION
This PR contains:

- check if there is a state before `preserveState`. If not, we get some undefined server errors because it tries to preserve a non existing state

- moves `registerModule` to `beforeMount`. We get undefined errors on client-side navigation when modules is unregistered on `destroyed` and we navigate back

- check if there is data on the registered module, before dispatch action to fetch data. This avoid fetch data two times when we land on a route with lazy loaded module: once on serverPrefetch and once on beforeMount

I hope it helps :)