### PR TITLE
Docs: Patch fetchItem method store access in Item.vue

### DIFF
--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -131,7 +131,7 @@ export default {
   methods: {
     fetchItem () {
       // return the Promise from the action
-      return store.dispatch('fetchItem', this.$route.params.id)
+      return this.$store.dispatch('fetchItem', this.$route.params.id)
     }
   }
 }


### PR DESCRIPTION
## This PR contains:
- Docs: Patch `fetchItem` method to access the store in `Item.vue` component.