### PR TITLE
Removed CommonsChunkPlugin

### DIFF
--- a/docs/guide/build-config.md
+++ b/docs/guide/build-config.md
@@ -92,14 +92,16 @@ const VueSSRClientPlugin = require('vue-server-renderer/client-plugin')
 
 module.exports = merge(baseConfig, {
   entry: '/path/to/entry-client.js',
+  // Important: this splits the webpack runtime into a leading chunk
+  // so that async chunks can be injected right after it.
+  // this also enables better caching for your app/vendor code
+  optimization: {
+    splitChunks: {
+      name: 'manifest',
+      minChunks: 1,
+    },
+  },
   plugins: [
-    // Important: this splits the webpack runtime into a leading chunk
-    // so that async chunks can be injected right after it.
-    // this also enables better caching for your app/vendor code.
-    new webpack.optimize.CommonsChunkPlugin({
-      name: "manifest",
-      minChunks: Infinity
-    }),
     // This plugins generates `vue-ssr-client-manifest.json` in the
     // output directory.
     new VueSSRClientPlugin()


### PR DESCRIPTION
From webpack documentation:
"Since webpack v4, the CommonsChunkPlugin was removed in favor of optimization.splitChunks."