### PR TITLE
Bump Vue version to a safe version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ::: tip NOTE
 This guide requires the following minimum versions of Vue and supporting libraries:
 
-- vue & vue-server-renderer 2.3.0+
+- vue & vue-server-renderer 2.6.0+
 - vue-router 2.5.0+
 - vue-loader 12.0.0+ & vue-style-loader 3.0.0+
 


### PR DESCRIPTION
- Vue 2.5.17 is the oldest version I would suggest to users as it contains a fix for XSS vulnerability[1] discovered by React team.
- Vue 2.6+ has the `serverPrefetch` hook which is referenced by the docs.

[1]: https://reactjs.org/blog/2018/08/01/react-v-16-4-2.html