### PR TITLE
Bump minimum node.js version recommendation

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -10,7 +10,7 @@ We will be using NPM throughout the guide, but feel free to use [Yarn](https://y
 
 #### Notes
 
-- It's recommended to use Node.js version 6+.
+- It's recommended to use Node.js version 8+.
 - `vue-server-renderer` and `vue` must have matching versions.
 - `vue-server-renderer` relies on some Node.js native modules and therefore can only be used in Node.js. We may provide a simpler build that can be run in other JavaScript runtimes in the future.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -10,7 +10,7 @@ We will be using NPM throughout the guide, but feel free to use [Yarn](https://y
 
 #### Notes
 
-- It's recommended to use Node.js version 8+.
+- It's recommended to use Node.js version 10+.
 - `vue-server-renderer` and `vue` must have matching versions.
 - `vue-server-renderer` relies on some Node.js native modules and therefore can only be used in Node.js. We may provide a simpler build that can be run in other JavaScript runtimes in the future.
 


### PR DESCRIPTION
Node.js 6 EOL is due on 30 April 2019, so the oldest recommended version should be now Node.js 8.