### PR TITLE
Add missing file to a basic SSR project structure

### DIFF
--- a/docs/guide/structure.md
+++ b/docs/guide/structure.md
@@ -71,6 +71,7 @@ src
 │   └── Baz.vue
 ├── App.vue
 ├── app.js # universal entry
+├── server.js # Express server
 ├── entry-client.js # runs in browser only
 └── entry-server.js # runs on server only
 ```


### PR DESCRIPTION
To avoid confusion I would suggest to add missing `server.js` which starts the Express server and runs the code from `app.js`.