### PR TITLE
docs: preserve state only at the client side

### DIFF
--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -240,7 +240,7 @@ export default {
 
   // Server-side only
   serverPrefetch () {
-    this.registerFoo()
+    this.$store.registerModule('foo', fooStoreModule)
     return this.fooInc()
   },
 
@@ -251,7 +251,8 @@ export default {
     const alreadyIncremented = !!this.$store.state.foo
 
     // We register the foo module
-    this.registerFoo()
+    // Preserve the previous state if it was injected from the server
+    this.$store.registerModule('foo', fooStoreModule, { preserveState: true })
 
     if (!alreadyIncremented) {
       this.fooInc()
@@ -265,11 +266,6 @@ export default {
   },
 
   methods: {
-    registerFoo () {
-      // Preserve the previous state if it was injected from the server
-      this.$store.registerModule('foo', fooStoreModule, { preserveState: true })
-    },
-
     fooInc () {
       return this.$store.dispatch('foo/inc')
     }


### PR DESCRIPTION
This PR fixes the Vuex `preserveState` option usage when registering a module. Originally raised at https://github.com/vuejs/vuex/pull/1611#issuecomment-618394773.

It make sure that `preserveState: true` is only applied at the client side.