### PR TITLE
fix error in Getting Started

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -171,7 +171,7 @@ const renderer = require('vue-server-renderer').createRenderer({
 
 const context = {
     title: 'vue ssr',
-    metas: `
+    meta: `
         <meta name="keyword" content="vue,ssr">
         <meta name="description" content="vue srr demo">
     `,

--- a/docs/ru/guide/README.md
+++ b/docs/ru/guide/README.md
@@ -170,7 +170,7 @@ const renderer = require('vue-server-renderer').createRenderer({
 
 const context = {
     title: 'vue ssr',
-    metas: `
+    meta: `
         <meta name="keyword" content="vue,ssr">
         <meta name="description" content="vue srr demo">
     `,

--- a/docs/zh/guide/README.md
+++ b/docs/zh/guide/README.md
@@ -170,7 +170,7 @@ const renderer = require('vue-server-renderer').createRenderer({
 
 const context = {
     title: 'vue ssr',
-    metas: `
+    meta: `
         <meta name="keyword" content="vue,ssr">
         <meta name="description" content="vue srr demo">
     `,


### PR DESCRIPTION
The above template use `{{{ meta }}}`, 

and the full demo use:
```
const context = {
    title: 'vue ssr',
    metas: `
        <meta name="keyword" content="vue,ssr">
        <meta name="description" content="vue srr demo">
    `,
};
```

it will cause a error： ReferenceError: meta is not defined

change metas to meta can be fixed