### PR TITLE
Updated docs to fix bug

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -140,7 +140,7 @@ const context = {
   `
 }
 
-renderer.renderToString(app, context, (err, html) => {
+renderer.renderToString(context, (err, html) => {
   // page title will be "Hello"
   // with meta tags injected
 })


### PR DESCRIPTION
When using the vue-renderer and passing a page template, you don't need to pass a vue instance to the `renderer.renderToString()` method

This [is also done in the vue-hackernews sample project.](https://github.com/vuejs/vue-hackernews-2.0/blob/master/server.js#L104)